### PR TITLE
Add Powershell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,17 @@ Add this alias to your config so you can type `lnks` from any directory to open 
 alias lnks='~/your-lnks-dir/lnks.sh'
 ```
 
+```powershell
+# add to $profile - check location with `Write-Output $profile`
+New-Alias lnks "$Home\your-lnks-dir\lnks.ps1"
+```
+
 ## Usage
 
-1. Run `lnks.sh`
+1. Run `lnks.sh` or `lnks.ps1`
 2. Type to run a fuzzy search against the names of your bookmarks
 3. Use arrow keys to navigate up and down
 4. Hit `Enter` to open a bookmark in your browser
-5. Hit `Esc` or `Ctrl-C` to exit
 
 
 ## Working with a team

--- a/lnks.ps1
+++ b/lnks.ps1
@@ -1,0 +1,12 @@
+#!/usr/bin/env pwsh
+
+$targetLink = cat ./bookmarks.txt | `
+  fzf `
+    --border=rounded --margin=5% `
+    --prompt="Search Bookmarks > " `
+    --with-nth='1..-2' `
+    --preview='echo {-1}' --preview-window='up,1' | `
+  sed 's/^.*\(https.*\)$/\1/'
+
+Start-Process $targetLink
+

--- a/lnks.ps1
+++ b/lnks.ps1
@@ -11,7 +11,9 @@ Catch [System.Management.Automation.CommandNotFoundException]
   Exit 1
 }
 
-$selection = Get-Content ./bookmarks.txt | fzf `
+$lnksDirectory = Split-Path -Path $PSCommandPath -Parent
+
+$selection = Get-Content "$lnksDirectory\*.txt" | fzf `
   --border=rounded --margin=5% `
   --prompt="Search Bookmarks > " `
   --with-nth='1..-2' `

--- a/lnks.ps1
+++ b/lnks.ps1
@@ -1,12 +1,10 @@
 #!/usr/bin/env pwsh
 
-$targetLink = cat ./bookmarks.txt | `
-  fzf `
-    --border=rounded --margin=5% `
-    --prompt="Search Bookmarks > " `
-    --with-nth='1..-2' `
-    --preview='echo {-1}' --preview-window='up,1' | `
-  sed 's/^.*\(https.*\)$/\1/'
+$selection = Get-Content ./bookmarks.txt | fzf `
+  --border=rounded --margin=5% `
+  --prompt="Search Bookmarks > " `
+  --with-nth='1..-2' `
+  --preview='echo {-1}' --preview-window='up,1'
 
+$targetLink = $selection.Split(' ')[-1]
 Start-Process $targetLink
-

--- a/lnks.ps1
+++ b/lnks.ps1
@@ -1,10 +1,25 @@
 #!/usr/bin/env pwsh
 
+try
+{
+  # try executing a dummy command to test if we have fzf installed, surpressing any output
+  fzf --version 2>&1 | out-null
+}
+Catch [System.Management.Automation.CommandNotFoundException]
+{
+  Write-Output "fzf is not installed"
+  Exit 1
+}
+
 $selection = Get-Content ./bookmarks.txt | fzf `
   --border=rounded --margin=5% `
   --prompt="Search Bookmarks > " `
   --with-nth='1..-2' `
   --preview='echo {-1}' --preview-window='up,1'
 
-$targetLink = $selection.Split(' ')[-1]
-Start-Process $targetLink
+# Only try to start process if last command (fzf) set its status to True and we have something to open
+if ( $? -and $selection )
+{
+  $targetLink = $selection.Split(' ')[-1]
+  Start-Process $targetLink
+}

--- a/lnks.sh
+++ b/lnks.sh
@@ -12,6 +12,13 @@ case "$OSTYPE" in
   *)        echo "unsupported OD: $OSTYPE" && exit 1 ;;
 esac
 
-ENTER_COMMAND="enter:execute(${OPEN_COMMAND} {-1} 2>/dev/null)"
+SELECTION=$(cat "$(dirname "$0")"/*.txt | fzf \
+  --border=rounded --margin=5% \
+  --prompt="Search Bookmarks > " \
+  --with-nth='1..-2' \
+  --preview='echo {-1}' --preview-window='up,1')
 
-cat "$(dirname "$0")"/*.txt | fzf --border=rounded --margin=5% --prompt="Search Bookmarks > " --with-nth='1..-2' --bind="${ENTER_COMMAND}" --preview='echo {-1}' --preview-window='up,1'
+if [ -n "$SELECTION" ]; then
+    TARGET_LINK=$(echo $SELECTION | sed 's/^.*\(https.*\)$/\1/')
+    $OPEN_COMMAND $TARGET_LINK 2>/dev/null
+fi


### PR DESCRIPTION
Addresses issue #1 by adding `lnks.ps1`. Tested on Mac and Windows.

Opted for an alternative way to execute what the user selects, without using `bind`. This led to me also changing `lnks.sh` for consistency.

I also got `execute:bind` working on windows but did not continue to find a cross platform solution. If that would be the preferred way I can simplify this PR a bit - given no cross-platform support tradeoff is ok. The proposed way better fits my personal workflow so I am biased. The only upside of using `bind` that I can think of would be opening multiple links without needing to specify the filter again, but even then its not smooth, since you need to keep alt-tabbing between opening links. Let me know what you think!

This does not address running inside WSL - we would need a way to break out of the container. Looking at this [superuser answer](https://superuser.com/questions/1262977/open-browser-in-host-system-from-windows-subsystem-for-linux) it might require some work beforehand by the user / depend on the operating system in use.