### PR TITLE
Feature/chrome bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ The rules:
 * You can have as many `.txt` files next to `lnks.sh` as you want
 
 
+### _Optional (for chrome users)_: Install `jq`
+
+For Chrome users, `lnks` also has functionality to automatically update the Bookmarks.txt file with your Chrome bookmarks. To enable this functionality you need to install `jq`.
+
+`jq` is a command-line JSON processor. We use it here to parse the contents of the Chrome Bookmarks file so these can be added to the Bookmarks file. Install it by following the [installation instructions](https://stedolan.github.io/jq/download/) or via a package manager of your choice:
+
+```bash
+sudo apt-get install jq # Ubuntu
+brew install jq # Mac OS
+sudo pacman -S jq # Arch
+chocolatey install jq # Windows
+```
+
 ### _Optional_: Create a global alias for easy access
 
 Add this alias to your config so you can type `lnks` from any directory to open your bookmarks:

--- a/get_chrome_bookmarks.sh
+++ b/get_chrome_bookmarks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+case "$OSTYPE" in
+  darwin*) BOOKMARKS_FILE=~/Library/Application\ Support/Google/Chrome/Default/Bookmarks ;;
+  linux*) BOOKMARKS_FILE=~/.config/google-chrome/Default/Bookmarks ;;
+  *) echo "Unsupported OD: $OSTYPE" && exit 1;;
+esac
+
+BOOKMARKS="$(jq -r '.roots.bookmark_bar | [.name,.] | recurse(. as [$path,$root] | $root | .children[]? | select(.type=="folder") | ["\($path)/\(.name)",.]) | . as [$path,{$children}] | ($children[] as {$type,$name,$url} | select($type=="url") | "\($name) \($url)")' "$BOOKMARKS_FILE")"
+
+echo "$BOOKMARKS"
+

--- a/get_default_browser.sh
+++ b/get_default_browser.sh
@@ -5,7 +5,7 @@ case "$OSTYPE" in
     BROWSER=$(plutil -p ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist | grep 'https' -b3 |awk 'NR==3 {split($4, arr, "\""); print arr[2]}')
     ;;
   linux*)
-    BROWSER=(xdg-settings get default-web-browser)
+    BROWSER=$(xdg-settings get default-web-browser)
     ;;
   *)
     echo "unsupported OD: $OSTYPE" && exit 1

--- a/get_default_browser.sh
+++ b/get_default_browser.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+case "$OSTYPE" in
+  darwin*)
+    BROWSER=$(plutil -p ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist | grep 'https' -b3 |awk 'NR==3 {split($4, arr, "\""); print arr[2]}')
+    ;;
+  linux*)
+    BROWSER=(xdg-settings get default-web-browser)
+    ;;
+  *)
+    echo "unsupported OD: $OSTYPE" && exit 1
+    ;;
+esac
+
+echo $BROWSER

--- a/lnks.sh
+++ b/lnks.sh
@@ -15,7 +15,7 @@ esac
 DEFAULT_BROWSER=$(sh $(dirname "$0")/get_default_browser.sh)
 
 # If chrome being used as default browser then updates the bookmarks file with Chrome bookmarks
-if [[ $DEFAULT_BROWSER = "com.google.chrome" || $DEFAULT_BROWSER = "google-chrome.desktop" ]]; then
+if [[ $DEFAULT_BROWSER = *"google"*"chrome"* ]]; then
   if ! [ -x "$(command -v jq)" ]; then
     echo "jq is not installed"
     exit 1

--- a/lnks.sh
+++ b/lnks.sh
@@ -14,4 +14,4 @@ esac
 
 ENTER_COMMAND="enter:execute(${OPEN_COMMAND} {-1} 2>/dev/null)"
 
-cat *.txt | fzf --border=rounded --margin=5% --prompt="Search Bookmarks > " --with-nth='1..-2' --bind="${ENTER_COMMAND}" --preview='echo {-1}' --preview-window='up,1'
+cat ~/lnks/*.txt | fzf --border=rounded --margin=5% --prompt="Search Bookmarks > " --with-nth='1..-2' --bind="${ENTER_COMMAND}" --preview='echo {-1}' --preview-window='up,1'

--- a/lnks.sh
+++ b/lnks.sh
@@ -12,6 +12,18 @@ case "$OSTYPE" in
   *)        echo "unsupported OD: $OSTYPE" && exit 1 ;;
 esac
 
+DEFAULT_BROWSER=$(sh $(dirname "$0")/get_default_browser.sh)
+
+# If chrome being used as default browser then updates the bookmarks file with Chrome bookmarks
+if [[ $DEFAULT_BROWSER = "com.google.chrome" || $DEFAULT_BROWSER = "google-chrome.desktop" ]]; then
+  if ! [ -x "$(command -v jq)" ]; then
+    echo "jq is not installed"
+    exit 1
+  else
+    echo "$(sh $(dirname "$0")/get_chrome_bookmarks.sh)" > ~/lnks/bookmarks.txt
+  fi;
+fi;
+
 ENTER_COMMAND="enter:execute(${OPEN_COMMAND} {-1} 2>/dev/null)"
 
-cat ~/lnks/*.txt | fzf --border=rounded --margin=5% --prompt="Search Bookmarks > " --with-nth='1..-2' --bind="${ENTER_COMMAND}" --preview='echo {-1}' --preview-window='up,1'
+cat "$(dirname "$0")"/*.txt | fzf --border=rounded --margin=5% --prompt="Search Bookmarks > " --with-nth='1..-2' --bind="${ENTER_COMMAND}" --preview='echo {-1}' --preview-window='up,1'

--- a/lnks.sh
+++ b/lnks.sh
@@ -16,10 +16,7 @@ DEFAULT_BROWSER=$(sh $(dirname "$0")/get_default_browser.sh)
 
 # If chrome being used as default browser then updates the bookmarks file with Chrome bookmarks
 if [[ $DEFAULT_BROWSER = *"google"*"chrome"* ]]; then
-  if ! [ -x "$(command -v jq)" ]; then
-    echo "jq is not installed"
-    exit 1
-  else
+  if [ -x "$(command -v jq)" ]; then
     echo "$(sh $(dirname "$0")/get_chrome_bookmarks.sh)" > ~/lnks/bookmarks.txt
   fi;
 fi;


### PR DESCRIPTION
### Automatically Add Bookmarks from Chrome

Don't know if you were looking to extend this repo but I've introduced scripts to automatically parse Chrome bookmarks and add them to the bookmarks.txt to save the user from having to do this manually.

**Summary of Changes**

- Added get_default_browser.sh that gets a users' default browser to check whether they're using Chrome
- Added get_chrome_bookmarks.sh that uses jq to parse the Chrome bookmarks file and output them in the same format as bookmarks.txt (e.g. "bookmark-name" "bookmark-url") - this script parses the full bookmarks tree so will also parse bookmarks from bookmarks subfolders. At the moment this outputs all bookmarks in a flat structure.
- Added logic to lnks.sh to check whether a user's default browser is Chrome and jq is installed and if so will update the bookmarks.txt file with their Chrome bookmarks
- Updated the README with instructions for installing jq

**Testing**
Currently the code has only been tested on mac but I've tried to make it compatible with both mac and linux

**Other Comments**
Currently only chrome bookmarks are supported but if people liked this functionality then it could be similarly applied to other browsers like Firefox. This would require a separate script as Firefox stores bookmarks differently to Chrome but should still be relatively straightforward to parse this file.