### PR TITLE
Added --no-messages to grep command, usage message via --help

### DIFF
--- a/lnks.sh
+++ b/lnks.sh
@@ -5,22 +5,28 @@ set -o errexit
 set -o nounset
 
 if ! [ -x "$(command -v fzf)" ]; then
-    echo "fzf is not installed"
+    echo "fzf is not installed" >&2
     exit 1
 fi
 
 keep_open=false
 
+usage () {
+  echo "Usage: $(basename $0) [OPTIONS...]"
+  echo "  -k    --keep-open     Keep lnks open after selecting a bookmark"
+  exit 0
+}
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -k|--keep-open) keep_open=true ;;
-        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+        -h|--help) usage;;
+        *) echo "Unknown parameter passed: $1" >&2; exit 1 ;;
     esac
     shift
 done
 
-
-if [[ $(grep -i Microsoft /proc/version) ]]; then
+if [[ $(grep --no-messages -i Microsoft /proc/version) ]]; then
     open_command="explorer.exe"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     open_command="open"
@@ -28,9 +34,7 @@ elif [[ "$OSTYPE" == "linux"* ]]; then
     open_command="xdg-open"
 fi
 
-
 enter_command="enter:execute-silent(${open_command} {-1})"
-
 
 if [ "$keep_open" = false ]; then
     enter_command="${enter_command}+abort"


### PR DESCRIPTION
### Changes
Running `lnks` on OSX the  application was flagging the following error:

```
grep: /proc/version: No such file or directory
```

Similar issue described [here](https://github.com/bendyworks/buffet/issues/108). Adding `--no-messages` to `grep resolves the issue.

Additional changes completed:

#### Added
- Added `stderr` redirect for error messages
- Added `usage()` function triggered by `-h|--help` options

#### Removed
- Extra blank lines between certain code blocks