### PR TITLE
Add --dir option to specify a directory bookmarks are stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ New-Alias lnks "$Home\your-lnks-dir\lnks.ps1"
 
 ```
 Usage: lnks.sh [OPTIONS...]
-  -k    --keep-open     Keep lnks open after selecting a bookmark
+  -k        --keep-open     Keep lnks open after selecting a bookmark
+  -d <dir>  --dir <dir>     Specify a directory bookmarks are stored (*nix only)
 ```
 
 ## Working with a team

--- a/lnks.sh
+++ b/lnks.sh
@@ -22,7 +22,7 @@ usage () {
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -k|--keep-open) keep_open=true ;;
-		-d|--dir) dir="$2"; shift ;; # TODO: validation
+        -d|--dir) dir="$2"; shift ;; # TODO: validation
         -h|--help) usage ;;
         *) echo "Unknown parameter passed: $1" >&2; exit 1 ;;
     esac

--- a/lnks.sh
+++ b/lnks.sh
@@ -12,7 +12,7 @@ fi
 keep_open=false
 
 usage () {
-  echo "Usage: $(basename $0) [OPTIONS...]"
+  echo "Usage: $(basename "$0") [OPTIONS...]"
   echo "  -k    --keep-open     Keep lnks open after selecting a bookmark"
   exit 0
 }

--- a/lnks.sh
+++ b/lnks.sh
@@ -10,17 +10,20 @@ if ! type fzf &> /dev/null; then
 fi
 
 keep_open=false
+dir="$(dirname "$0")"
 
 usage () {
   echo "Usage: $(basename "$0") [OPTIONS...]"
-  echo "  -k    --keep-open     Keep lnks open after selecting a bookmark"
+  echo "  -k        --keep-open     Keep lnks open after selecting a bookmark"
+  echo "  -d <dir>  --dir <dir>     Specify a directory bookmarks are stored"
   exit 0
 }
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -k|--keep-open) keep_open=true ;;
-        -h|--help) usage;;
+		-d|--dir) dir="$2"; shift ;; # TODO: validation
+        -h|--help) usage ;;
         *) echo "Unknown parameter passed: $1" >&2; exit 1 ;;
     esac
     shift
@@ -42,7 +45,7 @@ else
     enter_command="${enter_command}+abort"
 fi
 
-cat "$(dirname "$0")"/*.txt | fzf \
+cat "$dir"/*.txt | fzf \
   --border=rounded \
   --prompt="Search Bookmarks > " \
   --with-nth='1..-2' \


### PR DESCRIPTION
# Usage

```bash
./lnks.sh --dir ~/Documents/bookmarks -k
```

I added the --dir option. It's useful to store and sync bookmarks separately from the script file.

# Concern

Two concerns can be argued I think.

The first one is that no validation is implemented. So an unexpected behavior may occer when arguments weren't given correctly. For example, `./lnks.sh -d -k` (no dir) opens fzf window but it shows empty result.

The second is that I couldn't write powershell script because I don't have a windows machine.

Thank you for reading my proposal. It would make me happy if you merge my PR.